### PR TITLE
Settings: update Discussion settings section with extra info and a unique ID we can link to

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -53,7 +53,7 @@ function shareopenly_get_settings() {
  */
 function shareopenly_settings_init() {
 
-	add_settings_section( 'shareopenly_section', __( 'ShareOpenly', 'shareopenly' ), function () {}, 'discussion' );
+	add_settings_section( 'shareopenly_section', __( 'ShareOpenly', 'shareopenly' ), 'shareopenly_settings_section', 'discussion' );
 
 	add_settings_field( 'shareopenly_type', __( 'Sharing link location', 'shareopenly' ), 'shareopenly_type_callback', 'discussion', 'shareopenly_section', array( 'label_for' => 'shareopenly_type' ) );
 
@@ -69,6 +69,16 @@ function shareopenly_settings_init() {
 }
 
 add_action( 'admin_init', 'shareopenly_settings_init' );
+
+/**
+ * Settings main section paragraph.
+ */
+function shareopenly_settings_section() {
+	printf(
+		'<p id="shareopenly-settings">%s</p>',
+		esc_html__( 'ShareOpenly allows to add a sharing link to the bottom of posts and pages on your site. Use the settings below to customize the display of that sharing link.', 'shareopenly' )
+	);
+}
 
 /**
  * Type setting callback

--- a/inc/shared.php
+++ b/inc/shared.php
@@ -58,7 +58,7 @@ function shareopenly_action_links( $actions, $plugin_file ) {
 
 		// Add link to the settings page.
 		if ( current_user_can( 'manage_options' ) ) {
-			array_unshift( $actions, '<a href="options-discussion.php">' . __( 'Settings', 'shareopenly' ) . '</a>' );
+			array_unshift( $actions, '<a href="options-discussion.php#shareopenly-settings">' . __( 'Settings', 'shareopenly' ) . '</a>' );
 		}
 	}
 


### PR DESCRIPTION
In this PR, I'm suggesting 2 changes:

1. A new paragraph displayed at the top of the ShareOpenly settings, offering a bit more info.

<img width="1019" alt="image" src="https://github.com/dartiss/shareopenly/assets/426388/4eca3074-daa6-4251-a9bf-a3118d1c1aed">

2. That paragraph has a unique ID, so we can link to it directly from the Plugins List screen, thus making things a bit easier to understand for site owners. They won't have to look for the setting to change, they'll be directed to it:


https://github.com/dartiss/shareopenly/assets/426388/b5f976b9-368b-4f60-a63b-6b7c5228ce5b

Let me know what you think about it!